### PR TITLE
Fix translation function call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 file(GLOB TS_FILES translations/*.ts)
-qt5_create_translation(QM_FILES ${TS_FILES})
+qt5_create_translation(QM_FILES ${CMAKE_SOURCE_DIR} ${TS_FILES})
 add_custom_target(translations DEPENDS ${QM_FILES} SOURCES ${TS_FILES})
 add_dependencies(${PROJECT_NAME} translations)
 


### PR DESCRIPTION
I've read this: https://doc.qt.io/qt-5/qtlinguist-cmake-qt5-create-translation.html
Sounds a full path can fixed the trans issue.
e.g.

> [build] cd /home/loaden/.dev/Projects/cutefish/statusbar/build && /usr/lib/qt5/bin/lupdate @ -ts /home/loaden/.dev/Projects/cutefish/statusbar/translations/be_Latn.ts
[build] QFSFileEngine::open: No file name specified
[build] lupdate error: List file '' is not readable.