### PR TITLE
Update actions/checkout in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     container: docker.io/library/debian:sid
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Update repository
       run: apt-get update -y
     - name: Install the basic dev packages
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Update repository
       run: sudo apt-get update -y
     - name: Install the basic dev packages


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflows to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.